### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "ruby main.rb"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # ruby_Hangman
 This project is from [The Odin Project](https://www.theodinproject.com/courses/ruby-programming/lessons/file-i-o-and-serialization)
+
+[![Run on Repl.it](https://repl.it/badge/github/rlmoser99/ruby_hangman)](https://repl.it/github/rlmoser99/ruby_hangman)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).